### PR TITLE
Introducing rabbitmq:listen command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "sentry/sentry": "^4.0",
         "symfony/http-client": "^6.0",
         "nyholm/psr7": "^1.8",
-        "ramsey/uuid": "^4.7"
+        "ramsey/uuid": "^4.7",
+        "symfony/process": "^7.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/http-client": "^6.0",
         "nyholm/psr7": "^1.8",
         "ramsey/uuid": "^4.7",
-        "symfony/process": "^7.0"
+        "symfony/process": "^5|^6|^7.0"
     },
     "extra": {
         "laravel": {

--- a/src/Console/Commands/RabbitMQListenCommand.php
+++ b/src/Console/Commands/RabbitMQListenCommand.php
@@ -5,21 +5,21 @@ namespace Channext\ChannextRabbitmq\Console\Commands;
 use Illuminate\Console\Command;
 use Channext\ChannextRabbitmq\Facades\RabbitMQ;
 
-class RabbitMQCommand extends Command
+class RabbitMQListenCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'rabbitmq:consume {--once : Process a single message and exit}';
+    protected $signature = 'rabbitmq:listen';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Consume RabbitMQ';
+    protected $description = 'Listen RabbitMQ';
 
     /**
      * Create a new command instance.
@@ -38,7 +38,6 @@ class RabbitMQCommand extends Command
      */
     public function handle()
     {
-        $once = $this->option('once');
-        RabbitMQ::consume($once);
+        RabbitMQ::listenEvents();
     }
 }

--- a/src/Facades/RabbitMQ.php
+++ b/src/Facades/RabbitMQ.php
@@ -11,6 +11,8 @@ use Channext\ChannextRabbitmq\RabbitMQ\RabbitMQ as BaseRabbitMQ;
  * @method static void publish(array $body, string $routingKey, string|int $identifier = null)
  * @method static void function consume()
  * @method static null|RabbitMQMessage current()
+ * @method static void consume()
+ * @method static void listenEvents()
  **/
 class RabbitMQ extends Facade
 {

--- a/src/Providers/RabbitMQServiceProvider.php
+++ b/src/Providers/RabbitMQServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Channext\ChannextRabbitmq\Providers;
 
 use Channext\ChannextRabbitmq\Console\Commands\RabbitMQCommand;
+use Channext\ChannextRabbitmq\Console\Commands\RabbitMQListenCommand;
 use Channext\ChannextRabbitmq\RabbitMQ\RabbitMQ;
 use Illuminate\Support\ServiceProvider;
 
@@ -54,6 +55,7 @@ class RabbitMQServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 RabbitMQCommand::class,
+                RabbitMQListenCommand::class
             ]);
         }
     }

--- a/src/RabbitMQ/RabbitMQ.php
+++ b/src/RabbitMQ/RabbitMQ.php
@@ -500,9 +500,10 @@ class RabbitMQ
         $this->setCurrentMessage(null);
     }
 
-    protected function makeProcess($path)
+    protected function makeProcess($path = null)
     {
         $command = ['php', 'artisan', 'rabbitmq:consume', '--once'];
+        if (!$path && function_exists('base_path')) $path = base_path();
         return new Process(
             $command,
             $path,
@@ -512,10 +513,10 @@ class RabbitMQ
         );
     }
 
-    public function listenEvents($path) {
+    public function listenEvents($path = null) {
         while(true) {
             if ($this->hasMessage()) {
-                $process = $this->makeProcess();
+                $process = $this->makeProcess($path);
                 $process->run();
                 Log::info('RabbitMQ message consumed');
             } else {

--- a/src/RabbitMQ/RabbitMQ.php
+++ b/src/RabbitMQ/RabbitMQ.php
@@ -121,6 +121,8 @@ class RabbitMQ
     }
 
     /**
+     * Regular ever running consumer.
+     *
      * @return void
      * @throws ErrorException
      */
@@ -131,6 +133,8 @@ class RabbitMQ
     }
 
     /**
+     * listens for messages, if found processes one and returns
+     *
      * @return void
      */
     protected function listen() : void
@@ -140,6 +144,7 @@ class RabbitMQ
     }
 
     /**
+     * Returns true if there is a message in the queue
      * @return bool
      */
     public function hasMessage() : bool
@@ -148,7 +153,7 @@ class RabbitMQ
     }
 
     /**
-     * Purge queue
+     * Purge the queue
      *
      * @return void
      */
@@ -500,7 +505,13 @@ class RabbitMQ
         $this->setCurrentMessage(null);
     }
 
-    protected function makeProcess($path = null)
+    /**
+     * Creates a one time listener process
+     *
+     * @param null|string $path
+     * @return Process
+     */
+    protected function makeProcess(?string $path = null): Process
     {
         $command = ['php', 'artisan', 'rabbitmq:consume', '--once'];
         if (!$path && function_exists('base_path')) $path = base_path();
@@ -513,7 +524,15 @@ class RabbitMQ
         );
     }
 
-    public function listenEvents($path = null) {
+    /**
+     * Listens for messages and processes them in a separate process
+     * enabling hot-reloading.
+     *
+     * @param null|string $path
+     * @return void
+     */
+    public function listenEvents(?string $path = null): void
+    {
         while(true) {
             if ($this->hasMessage()) {
                 $process = $this->makeProcess($path);

--- a/src/RabbitMQ/RabbitMQ.php
+++ b/src/RabbitMQ/RabbitMQ.php
@@ -518,7 +518,6 @@ class RabbitMQ
             if ($this->hasMessage()) {
                 $process = $this->makeProcess($path);
                 $process->run();
-                Log::info('RabbitMQ message consumed');
             } else {
                 //delay 100ms
                 usleep(100000);


### PR DESCRIPTION
Introducing rabbitmq:listen command!

with its cutting edge technology it enables hot reloading even when the command running!
Now that you have it you won't have to re-run consume command every time you make changes.

Note: this probably has lower performance than rabbitmq:consume but it's only for development purposes