### PR TITLE
binding seeder is added

### DIFF
--- a/src/Facades/RabbitMQ.php
+++ b/src/Facades/RabbitMQ.php
@@ -16,6 +16,10 @@ use Channext\ChannextRabbitmq\RabbitMQ\RabbitMQ as BaseRabbitMQ;
  * @method static void consume()
  * @method static void listenEvents(array $options)
  * @method static void test(string $route, RabbitMQMessage $message)
+ * @method static array getDefinedRoutes()
+ * @method static array getBindings(?string $queue = null, ?string $exchange = null, ?string $vhost = '/')
+ * @method static bool deleteBinding(string $route, ?string $queue = null, ?string $exchange = null, ?string $vhost = '/')
+ * @method static bool unbindUnused()
  **/
 class RabbitMQ extends Facade
 {

--- a/src/Seeders/BindTopicsSeeder.php
+++ b/src/Seeders/BindTopicsSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Channext\ChannextRabbitmq\Seeders;
+
+use Channext\ChannextRabbitmq\Facades\RabbitMQ;
+use Exception;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Log;
+
+use function Sentry\captureException;
+
+class BindTopicsSeeder extends Seeder
+{
+    /**
+     * Seed the application's database.
+     */
+    public function run(): void
+    {
+        try {
+            RabbitMQ::unbindUnused();
+        } catch (Exception $e) {
+            captureException($e);
+            Log::error('Failed to unbind unused topics: ' . $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
with this pull request, the ability to check if the existing bindings are still defined in the topics.php file. If a binding does not exist on the existing version of topics.php it will be removed from the bindings.

Includes methods such as getDefinedRoutes(), getBindings(), deleteBinding() and most importantly unbindUnused()